### PR TITLE
Add filter based on time range, packet number ranges, and for a specific packet

### DIFF
--- a/src/tool_calling_handler.py
+++ b/src/tool_calling_handler.py
@@ -395,6 +395,7 @@ The filter will be automatically extracted and applied to the pcap file using py
                 updated_analysis_data = result["filtered_data"]
                 print(f"🔄 Updated analysis data with filtered results from {function_name}")
                 self.log_debug(f"📊 Updated analysis data with filtered results")
+                print(f"📊 Filtered data contains {len(updated_analysis_data.get('packets', []))} packets")
             
             tool_results.append({
                 "tool_call_id": tool_call["id"],


### PR DESCRIPTION
Testing: 

Packet ranges:
 
🤖 pcapAI> Can you provide me a summary of all the packets between packet number 4 and 24? Please list the packet numbers too

🤖 Processing...

🔧 TOOL CALLING HANDLER - Starting query processing

📝 User Question: Can you provide me a summary of all the packets between packet number 4 and 24? Please list the packet numbers too

📊 Analysis Data Keys: ['protocol', 'packet_count', 'packets']

📁 No existing filtered data file found, using original analysis data

🛠️ Available tools: ['filter_packets_by_protocol', 'filter_packets_by_ip', 'filter_packets_by_operation', 'filter_packets_by_time_range', 'filter_packets_by_packet_number_range']

📨 Total messages to send: 2

📤 Context length: 1006 characters

🚀 Attempt 1/3: Sending query to OpenAI API...

✅ API Response received successfully

{'content': None, 'role': 'assistant', 'tool_calls': [{'function': {'arguments': '{"start_number":4,"end_number":24}', 'name': 'filter_packets_by_packet_number_range'}, 'id': 'call_EOpMNZFL05h9FLUJtE7eONXv', 'type': 'function'}], 'function_call': None, 'annotations': []}

🔍 Response has tool_calls: True

🔧 Tool calls detected: 1 tools to execute
 
============================================================

🔧 STARTING TOOL CALLING WORKFLOW

============================================================

🔨 Executing 1 tool calls...

🔧 Tool 1: filter_packets_by_packet_number_range

📋 Arguments: {'start_number': 4, 'end_number': 24}

[DEBUG] Executing filter tool: filter_packets_by_packet_number_range

[DEBUG] Tool arguments: {'start_number': 4, 'end_number': 24}

[DEBUG] Analysis data keys: ['protocol', 'packet_count', 'packets']

[DEBUG] Total packets in analysis_data: 301

✅ Tool 1 execution completed

📊 Result keys: ['status', 'message', 'packets_filtered', 'filtered_data']

🔄 Updated analysis data with filtered results from filter_packets_by_packet_number_range

📊 Filtered data contains 21 packets

📝 Adding tool results to conversation context...

📨 Total messages in conversation: 4
 
🔄 ROUND 1: Getting initial AI response after tool execution...

✅ Round 1 successful - Response length: 1024 characters
 
🔄 ROUND 2: Providing filtered data context for analysis...

📊 Filtered data contains 21 packets

✅ Round 2 successful - Response length: 1899 characters
 
🔄 ROUND 3: Getting final comprehensive response...

✅ Round 3 successful - Final response length: 2739 characters

🔍 Extracting pyshark filter from AI response...

✅ Found protocol-based filter: smb2

🔍 Found pyshark filter in final response: smb2

🔧 Applying pyshark filter 'smb2' to /Users/pratult/Downloads/write-back-sktraces-logs/write-back-revit-issue-inhouse-client-trace.pcapng

✅ Filtered capture complete: 301 packets found

🔄 Converting filtered packets to JSON...

✅ Successfully converted 301 packets to JSON

🎉 TOOL CALLING WORKFLOW COMPLETED SUCCESSFULLY WITH PYSHARK FILTER

============================================================
 
==================================================

🤖 AI RESPONSE

==================================================

Here is a comprehensive summary of the packets between packet numbers 4 and 24:
 
1. **Packet 4**: SMB2 Create Request

   - Command: Create (cmd == 5)

   - Filename: Revit\Snowdon Towers Sample Architectural_central_backup\corrupt

   - Status: Request sent
 
2. **Packet 5**: TCP Acknowledgment

   - Acknowledgment for the SMB2 Create Request
 
3. **Packet 6**: SMB2 Create Response

   - Command: Create (cmd == 5)

   - NT Status: 0xc0000034 (Object Name Not Found)

   - Status: Error response indicating the object name was not found
 
4. **Packet 7**: SMB2 Create Request

   - Command: Create (cmd == 5)

   - Filename: Revit\Snowdon Towers Sample Architectural_central.rvt

   - Status: Request sent
 
5. **Packet 8**: SMB2 Create Response

   - Command: Create (cmd == 5)

   - NT Status: 0x00000000 (Success)

   - Status: Successful response
 
6. **Packet 9**: SMB2 Close Request

   - Command: Close (cmd == 6)

   - Status: Request sent
 
7. **Packet 10**: SMB2 Close Response

   - Command: Close (cmd == 6)

   - NT Status: 0x00000000 (Success)

   - Status: Successful response
 
8. **Packet 11**: SMB2 Create Request

   - Command: Create (cmd == 5)

   - Filename: Revit\Snowdon Towers Sample Architectural_central_backup\users.dat

   - Status: Request sent
 
9. **Packet 12**: SMB2 Create Response

   - Command: Create (cmd == 5)

   - NT Status: 0x00000000 (Success)

   - Status: Successful response
 
10. **Packet 13**: SMB2 Close Request

    - Command: Close (cmd == 6)

    - Status: Request sent
 
11. **Packet 14**: SMB2 Close Response

    - Command: Close (cmd == 6)

    - NT Status: 0x00000000 (Success)

    - Status: Successful response
 
12. **Packet 15**: SMB2 Create Request

    - Command: Create (cmd == 5)

    - Filename: Revit\Snowdon Towers Sample Architectural_central_backup\users.dat

    - Status: Request sent
 
13. **Packet 16**: SMB2 Create Response

    - Command: Create (cmd == 5)

    - NT Status: 0x00000000 (Success)

    - Status: Successful response
 
14. **Packet 17**: SMB2 Create Request

    - Command: Create (cmd == 5)

    - Filename: Revit\Snowdon Towers Sample Architectural_central_backup

    - Status: Request sent
 
15. **Packet 18**: SMB2 Create Response

    - Command: Create (cmd == 5)

    - NT Status: 0x00000000 (Success)

    - Status: Successful response
 
16. **Packet 19**: SMB2 Find Request

    - Command: Find (cmd == 14)

    - Status: Request sent
 
17. **Packet 20-23**: TCP Data Transfer

    - Series of TCP packets transferring data
 
18. **Packet 24**: SMB2 Find Response

    - Command: Find (cmd == 14)

    - NT Status: 0x80000006 (Error)

    - Status: Error response indicating an issue with the find operation
 
Overall, the packets between 4 and 24 involve a series of SMB2 operations including create,
 
--- Pyshark Filter Applied ---

Filter: smb2

Packets found: 301

Status: Applied pyshark filter 'smb2' and found 301 matching packets

Filtered packet data has been generated and is available for analysis.
 
🤖 pcapAI> Can you please elaborate for packet 19? What went wrong?

🤖 Processing...

🔧 TOOL CALLING HANDLER - Starting query processing

📝 User Question: Can you please elaborate for packet 19? What went wrong?

📊 Analysis Data Keys: ['protocol', 'packet_count', 'packets']

📁 No existing filtered data file found, using original analysis data

🛠️ Available tools: ['filter_packets_by_protocol', 'filter_packets_by_ip', 'filter_packets_by_operation', 'filter_packets_by_time_range', 'filter_packets_by_packet_number_range']

📨 Total messages to send: 4

📤 Context length: 1006 characters

🚀 Attempt 1/3: Sending query to OpenAI API...

✅ API Response received successfully

{'content': 'Packet 19 is an SMB2 Find Request. This packet is part of the process where a client requests a directory listing or searches for files within a directory on the server. \n\nIn this specific case, the SMB2 Find Request was sent to the server, but the subsequent response (Packet 24) indicated an error with NT Status: 0x80000006. This status code corresponds to "STATUS_NO_MORE_FILES," which means that the server has reached the end of the file list or directory contents, and there are no more files to return in the response.\n\nThis error is not necessarily indicative of a problem; it simply means that the server has completed the directory listing and there are no additional files to send back to the client. This is a common status code when a directory listing operation reaches its natural conclusion.', 'role': 'assistant', 'tool_calls': None, 'function_call': None, 'annotations': []}

🔍 Response has tool_calls: False

💬 No tool calls - checking for pyshark filter in direct response

🔍 Extracting pyshark filter from AI response...

✅ Found protocol-based filter: smb2

� Found pyshark filter in response: smb2

🔧 Applying pyshark filter 'smb2' to /Users/pratult/Downloads/write-back-sktraces-logs/write-back-revit-issue-inhouse-client-trace.pcapng

✅ Filtered capture complete: 301 packets found

🔄 Converting filtered packets to JSON...

✅ Successfully converted 301 packets to JSON
 
==================================================

🤖 AI RESPONSE

==================================================

Packet 19 is an SMB2 Find Request. This packet is part of the process where a client requests a directory listing or searches for files within a directory on the server.
 
In this specific case, the SMB2 Find Request was sent to the server, but the subsequent response (Packet 24) indicated an error with NT Status: 0x80000006. This status code corresponds to "STATUS_NO_MORE_FILES," which means that the server has reached the end of the file list or directory contents, and there are no more files to return in the response.
 
This error is not necessarily indicative of a problem; it simply means that the server has completed the directory listing and there are no additional files to send back to the client. This is a common status code when a directory listing operation reaches its natural conclusion.
 
--- Pyshark Filter Applied ---

Filter: smb2

Packets found: 301

Status: Applied pyshark filter 'smb2' and found 301 matching packets
